### PR TITLE
Add acceptsTypes method to Handlers

### DIFF
--- a/src/Handlers.php
+++ b/src/Handlers.php
@@ -85,6 +85,16 @@ class Handlers
         return $this->filter(fn (Method $method) => $method->accepts(...$input));
     }
 
+    /**
+     * @param string[] $input
+     *
+     * @return self
+     */
+    public function acceptsTypes(array $input):self
+    {
+        return $this->filter(fn(Method $method) => $method->acceptsTypes($input));
+    }
+
     public function public(): self
     {
         $clone = clone $this;

--- a/src/Handlers.php
+++ b/src/Handlers.php
@@ -86,7 +86,7 @@ class Handlers
     }
 
     /**
-     * @param string[] $input
+     * @param array<string> $input
      *
      * @return self
      */

--- a/src/Method.php
+++ b/src/Method.php
@@ -51,6 +51,21 @@ class Method
         return true;
     }
 
+    public function acceptsTypes(array $input): bool
+    {
+        if (count($input) !== $this->inputCount) {
+            return false;
+        }
+
+        foreach ($this->positionalTypes as $index => $type) {
+            if (! $type->hasName($input[$index])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     public function getName(): string
     {
         return $this->reflectionMethod->getName();

--- a/src/Type.php
+++ b/src/Type.php
@@ -61,6 +61,11 @@ class Type
         }
     }
 
+    public function hasName(string $name): bool
+    {
+        return $this->getName() === $name;
+    }
+
     public function getName(): string
     {
         return $this->name;

--- a/tests/HandlersTest.php
+++ b/tests/HandlersTest.php
@@ -89,6 +89,31 @@ class HandlersTest extends TestCase
                 ->first()
         );
     }
+
+    /**
+     * @test
+     */
+    public function test_acceptsTypes()
+    {
+        $this->assertNull(
+            Handlers::new(Baz::class)
+            ->acceptsTypes(['foo'])
+            ->first()
+        );
+
+        $this->assertCount(
+            2,
+            Handlers::new(Baz::class)
+                    ->acceptsTypes(['string'])
+                    ->all()
+        );
+
+        $this->assertNotNull(
+            Handlers::new(Baz::class)
+                    ->acceptsTypes(['string', 'int'])
+                    ->first()
+        );
+    }
 }
 
 class Baz
@@ -103,6 +128,11 @@ class Baz
 
     public function acceptsInt(int $a)
     {
+    }
+
+    public function multipleTypes(string $a, int $b)
+    {
+
     }
 
     private function invisible(array $input)

--- a/tests/HandlersTest.php
+++ b/tests/HandlersTest.php
@@ -90,9 +90,7 @@ class HandlersTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function test_acceptsTypes()
     {
         $this->assertNull(


### PR DESCRIPTION
I created this PR as a potential solution for https://github.com/spatie/laravel-event-sourcing/issues/341 

This PR adds an `acceptsTypes` function to the `Handlers` class that takes an array of strings and filters methods that match the provided types. This should add the flexibility needed in the event-sourcing library to ignore functions with a single untyped or mixed argument.