### PR TITLE
Use spatie/php-attribute-reader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/collections": "^10|^11.43.2|^12|^13.0"
+        "illuminate/collections": "^10|^11.43.2|^12|^13.0",
+        "spatie/php-attribute-reader": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.69.1",

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -8,6 +8,7 @@ use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionMethod;
 use Reflector;
+use Spatie\Attributes\Attributes as AttributeReader;
 
 /**
  * @template AttributeType
@@ -101,15 +102,13 @@ class Attributes
      */
     public function all(): iterable|Collection
     {
-        $allAttributes = [];
-
-        if ($this->instanceOf) {
-            $attributes = $this->reflection->getAttributes($this->instanceOf, ReflectionAttribute::IS_INSTANCEOF);
-        } else {
-            $attributes = $this->reflection->getAttributes();
+        if (! $this->asAttributes && $this->filters === []) {
+            return collect($this->getInstantiatedAttributes());
         }
 
-        foreach ($attributes as $attribute) {
+        $allAttributes = [];
+
+        foreach ($this->getRawAttributes() as $attribute) {
             if (! $this->filterAllows($attribute)) {
                 continue;
             }
@@ -129,13 +128,48 @@ class Attributes
      */
     public function first(): mixed
     {
+        if (! $this->asAttributes && $this->filters === []) {
+            return $this->getInstantiatedAttributes()[0] ?? null;
+        }
+
         $first = $this->asAttributes()->all()->first();
 
         if (! $this->asAttributes) {
-            $first = $first->newInstance();
+            $first = $first?->newInstance();
         }
 
         return $first;
+    }
+
+    /**
+     * @return array<ReflectionAttribute>
+     */
+    private function getRawAttributes(): array
+    {
+        if ($this->instanceOf) {
+            return $this->reflection->getAttributes($this->instanceOf, ReflectionAttribute::IS_INSTANCEOF);
+        }
+
+        return $this->reflection->getAttributes();
+    }
+
+    /**
+     * @return array<object>
+     */
+    private function getInstantiatedAttributes(): array
+    {
+        if ($this->reflection instanceof ReflectionMethod) {
+            return AttributeReader::getAllOnMethod(
+                $this->reflection->getDeclaringClass()->getName(),
+                $this->reflection->getName(),
+                $this->instanceOf,
+            );
+        }
+
+        return AttributeReader::getAll(
+            $this->reflection->getName(),
+            $this->instanceOf,
+        );
     }
 
     private function filterAllows(ReflectionAttribute $attribute): bool


### PR DESCRIPTION
## Summary

- Adds `spatie/php-attribute-reader` as a dependency
- Refactors `Attributes::all()` and `Attributes::first()` to delegate attribute instantiation to `Spatie\Attributes\Attributes` for the common code paths (no filters, no `asAttributes`)
- Extracts `getRawAttributes()` and `getInstantiatedAttributes()` private helpers to clarify the two distinct paths: raw reflection attributes (needed for filters/asAttributes) vs fully instantiated attributes
- All existing tests pass without modification